### PR TITLE
drop top-level endorsed-claims (it's a veraison extension)

### DIFF
--- a/datamodels/attestation-results/grammar/attestation-results.cddl
+++ b/datamodels/attestation-results/grammar/attestation-results.cddl
@@ -12,7 +12,6 @@ attestation-results = {
   ? ar.trust-vector => ar-trust-vector
   ? ar.raw-evidence => ar-bytes
   ar.timestamp => ar-timestamp
-  ? ar.endorsed-claims => ar-endorsed-claims
   ar.appraisal-policy-id => text
   * $$attestation-results-extension
 }
@@ -27,30 +26,6 @@ ar-trust-vector = {
   ar.storage-opaque => $ar-status
   ar.sourced-data => $ar-status
   * $$ar-trust-vector-extension
-}
-
-ar-endorsed-claims = non-empty<{
-  ? ar.hw-details => ar-hw-details
-  ? ar.sw-details => ar-sw-details
-  ? ar.certification-details => ar-certification-details
-  ? ar.config-details => ar-config-details
-  * $$ar-endorsed-claims-extension
-}>
-
-ar-hw-details = {
-  + ar-label => any
-}
-
-ar-sw-details = {
-  + ar-label => any
-}
-
-ar-config-details = {
-  + ar-label => any
-}
-
-ar-certification-details = {
-  + ar-label => any
 }
 
 ; vim: set tw=70 ts=2 et:

--- a/datamodels/attestation-results/grammar/cbor-labels.cddl
+++ b/datamodels/attestation-results/grammar/cbor-labels.cddl
@@ -9,8 +9,7 @@ ar.status = 0
 ar.trust-vector = 1
 ar.raw-evidence = 2
 ar.timestamp = 3
-ar.endorsed-claims = 4
-ar.appraisal-policy-id = 5
+ar.appraisal-policy-id = 4
 
 ; ar-trust-vector
 ar.instance-identity = 0
@@ -21,12 +20,6 @@ ar.hardware = 4
 ar.runtime-opaque = 5
 ar.storage-opaque = 6
 ar.sourced-data = 7
-
-; ar-endorsed-claims
-ar.hw-details = 0
-ar.sw-details = 1
-ar.certification-details = 2
-ar.config-details = 3
 
 ; types
 ar-timestamp = tdate

--- a/datamodels/attestation-results/grammar/examples/cbor-1.diag
+++ b/datamodels/attestation-results/grammar/examples/cbor-1.diag
@@ -12,5 +12,5 @@
   },
   2: h'6C696665626F61746D616E',
   3: 0("6182-02-30T22:32:47.439295z"),
-  5: "https://veraison.example/policy/1/60a0068d"
+  4: "https://veraison.example/policy/1/60a0068d"
 }

--- a/datamodels/attestation-results/grammar/examples/veraison-cbor-1.diag
+++ b/datamodels/attestation-results/grammar/examples/veraison-cbor-1.diag
@@ -12,7 +12,7 @@
   },
   2: h'6C696665626F61746D616E',
   3: 0("6182-02-30T22:32:47.439295z"),
-  5: "https://veraison.example/policy/1/60a0068d",
+  4: "https://veraison.example/policy/1/60a0068d",
   100: {
     "nonce": "aGpzZGZoZGEK",
     "client-id": 1,

--- a/datamodels/attestation-results/grammar/json-labels.cddl
+++ b/datamodels/attestation-results/grammar/json-labels.cddl
@@ -9,7 +9,6 @@ ar.status = "status"
 ar.trust-vector = "trust-vector"
 ar.raw-evidence = "raw-evidence"
 ar.timestamp = "timestamp"
-ar.endorsed-claims = "endorsed-claims"
 ar.appraisal-policy-id = "appraisal-policy-id"
 
 ; ar-trust-vector
@@ -22,15 +21,9 @@ ar.runtime-opaque = "runtime-opaque"
 ar.storage-opaque = "storage-opaque"
 ar.sourced-data = "sourced-data"
 
-; ar-endorsed-claims
-ar.hw-details = "hw-details"
-ar.sw-details = "sw-details"
-ar.certification-details = "certification-details"
-ar.config-details = "config-details"
-
 ; types
 ar-timestamp = text
-ar-bytes = text
+ar-bytes = text .regexp "[A-Za-z0-9_=-]+"
 ar-label = text
 
 ; vim: set tw=70 ts=2 et:


### PR DESCRIPTION
Removed redundant `ar-endorsed-claims` from the top-level attestation result.  It is now a veraison specific feature that goes by the name of `ar.veraison.verifier-added-claims`.


Signed-off-by: Thomas Fossati <thomas.fossati@arm.com>