### PR TITLE
Add correct PSA corim template

### DIFF
--- a/demo/psa/prov-verif-e2e/data/templates/corim-full.json
+++ b/demo/psa/prov-verif-e2e/data/templates/corim-full.json
@@ -7,8 +7,7 @@
     }
   ],
   "profiles": [
-    "1.3.6.1.4.1.4128.100",
-    "http://arm.com/iot/profile/1"
+    "http://arm.com/psa/iot/1"
   ],
   "validity": {
     "not-before": "2021-12-31T00:00:00Z",


### PR DESCRIPTION
This change corrects the corim-full.json template to only have one profile as multiple profiles are not permitted.

This addresses #25 