### PR TITLE
Align OpenAPI definition to real servers behaviour

### DIFF
--- a/api/challenge-response/schemas/components.yaml
+++ b/api/challenge-response/schemas/components.yaml
@@ -48,8 +48,9 @@ components:
         result:
           type: string
           description: >
-            the computed Attestation Result wrapped as payload in an JWS.
-            The wrapped Attestation Result is of type '#/components/schemas/AttestationResult'
+            The computed Attestation Result encoded as an EAR
+            (https://datatracker.ietf.org/doc/draft-fv-rats-ear) using the JWT
+            serialization.
 
     EvidenceContentType:
       type: string

--- a/api/challenge-response/schemas/components.yaml
+++ b/api/challenge-response/schemas/components.yaml
@@ -46,7 +46,7 @@ components:
           description: >
             the submitted attestation Evidence
         result:
-          $ref: '#/components/schemas/AttestationResult'
+          type: string
           description: >
             the computed Attestation Result
 

--- a/api/challenge-response/schemas/components.yaml
+++ b/api/challenge-response/schemas/components.yaml
@@ -48,7 +48,8 @@ components:
         result:
           type: string
           description: >
-            the computed Attestation Result
+            the computed Attestation Result wrapped as payload in an JWS.
+            The wrapped Attestation Result is of type '#/components/schemas/AttestationResult'
 
     EvidenceContentType:
       type: string


### PR DESCRIPTION
The server returns the AttestationResult wrapped in an JWS and not as plain '#/components/schemas/AttestationResult' as specified in api/challenge-response/schemas/components.yaml