### PR TITLE
fix(demo): correct services clone commands

### DIFF
--- a/demo/cca/manual-end-to-end.md
+++ b/demo/cca/manual-end-to-end.md
@@ -164,7 +164,7 @@ export TOPDIR=$(pwd)
 In the first shell, clone the Veraison services repository:
 
 ```shell
-git clone https://github.com/veraison/services@demo-cca-1.0.0
+git clone --branch demo-cca-1.0.0 https://github.com/veraison/services
 ```
 
 Build the services:

--- a/demo/psa/manual-end-to-end.md
+++ b/demo/psa/manual-end-to-end.md
@@ -157,7 +157,7 @@ export TOPDIR=$(pwd)
 In the first shell, clone the Veraison services repository:
 
 ```shell
-git clone https://github.com/veraison/services
+git clone --branch demo-psa-1.0.1 https://github.com/veraison/services
 ```
 
 Build the services:


### PR DESCRIPTION
In cca, correct the services clone command syntax to specify the tag using git's --branch option (which also works for tags); it was previously using golang syntax.

In psa, add --branch with the psa demo tag; previously, no ref was specified, so the latest would be cloned, potentially causing interop issues with other demo components.

Addresses https://github.com/veraison/docs/issues/54