### PR TITLE
the nonce query parameter is base64 URL-encoded

### DIFF
--- a/api/challenge-response/challenge-response.yaml
+++ b/api/challenge-response/challenge-response.yaml
@@ -30,8 +30,9 @@ paths:
           in: query
           description: >
             the API server should not generate a nonce for this session and
-            use instead the one supplied by the client. The supplied value must
-            decode to a byte sequence between 8 and 64 bytes long.
+            instead use the one supplied by the client. The supplied base64
+            URL-encoded value must decode to a byte sequence between 8 and
+            64 bytes long.
           required: false
           schema:
             type: string


### PR DESCRIPTION
There has been a disconnect between client and server implementations due to the lack of precision in the spec.