### PR TITLE
chore: refactor for use in Veraison book

### DIFF
--- a/api/challenge-response/README.md
+++ b/api/challenge-response/README.md
@@ -1,10 +1,12 @@
-# Interaction models
+# Challenge/Response
+
+## Interaction models
 
 The APIs described here are meant to be instantiations of the abstract
 protocols described in [Reference Interaction Models for Remote Attestation
 Procedures](https://datatracker.ietf.org/doc/draft-ietf-rats-reference-interaction-models/).
 
-## Challenge/Response
+## Session flow
 
 Each Challenge-Response session is associated to its own resource, with the
 following attributes:

--- a/api/endorsement-provisioning/README.md
+++ b/api/endorsement-provisioning/README.md
@@ -91,12 +91,12 @@ format is CoRIM.
              { "status": "processing|success|failed" }
 ```
 
+
 * Client submits the endorsement provisioning request
 * Server responds with response code `201` indicating that the request has been accepted and will be processed asynchronously
 * Server returns the URI of a time-bound session resource in the `Location` header. The resource can be polled at regular intervals to check the progress of the submission, until the processing is complete (either successfully or with a failure)
 
-### Example
-
+### Example
 
 ```text
 >> Request:

--- a/api/management/README.md
+++ b/api/management/README.md
@@ -4,7 +4,7 @@ The API described here are intended to assist with the operation and management
 of a Veraison services deployment. They are not meant to be utilized by the
 services' users.
 
-## Policy management
+# Policy management
 
 Policies allow augmenting attestation scheme generated [Attestation Results] on
 per-deployment basis, by specifying additional rules to be applied to these

--- a/repo-guide.md
+++ b/repo-guide.md
@@ -31,12 +31,15 @@ Veraison services expose REST APIs. This set of libraries provides convenient co
 This collection of libraries provides manipulation and verification functionality for Attestation formats of various architectures. 
 
 [psatoken](https://github.com/veraison/psatoken): Platform Security Abstraction (PSA) Attestation Token manipulation library.
+
 [ccatoken](https://github.com/veraison/ccatoken) 
 A library for the Arm Confidential Computing Architecture (CCA) Attestation Token.
-[dice](https://github.com/veraison/dice): library providing support functions for manipulating various profiles of DICE.
-[parsec](https://github.com/veraison/parsec): Library support for handling the Parsec Key Attestation formats used in the attested TLS PoC.
-[enact-demo](https://github.com/veraison/enact-demo): EnactTrust TPM/Veraison interop demo and related docs
 
+[dice](https://github.com/veraison/dice): library providing support functions for manipulating various profiles of DICE.
+
+[parsec](https://github.com/veraison/parsec): Library support for handling the Parsec Key Attestation formats used in the attested TLS PoC.
+
+[enact-demo](https://github.com/veraison/enact-demo): EnactTrust TPM/Veraison interop demo and related docs
 
 
 ## CLI tools 


### PR DESCRIPTION
Minor fixes and refactor to allow some parts of the documentation to be included in the Veraison book.