### PR TITLE
docs: add terminology document for key Veraison concepts

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -1,0 +1,77 @@
+# Veraison Terminology
+
+This document explains the key concepts and terms used in **Project Veraison**.  
+It is intended to help new contributors, developers, and users quickly understand the terminology.
+
+---
+
+## 🔹 Provisioning
+
+### **CoRIM (Concise Reference Integrity Manifest)**
+A data structure that provides trusted reference values (baselines) for attestation.  
+It defines what "good" looks like for a platform or component.  
+*(Defined in [IETF CoRIM draft](https://datatracker.ietf.org/doc/draft-birkholz-rats-corim/))*  
+
+### **CoMID (Concise Module Identifier)**
+A component of CoRIM that describes the identity and attributes of specific hardware or software modules.  
+It enables precise matching of evidence with reference values.  
+
+### **Endorsements**
+Statements issued by manufacturers or trusted authorities about a device/component, describing capabilities, identity, or measurement expectations.
+
+---
+
+## 🔹 Verification
+
+### **Evidence**
+Claims collected from a device (the Attester) about its current state (firmware, boot configuration, runtime properties).  
+
+### **Scheme**
+A verification policy or method supported by Veraison that defines how evidence should be interpreted and matched against reference values.  
+
+### **Verifier**
+The entity that validates evidence against endorsements and reference values to produce an attestation result.  
+
+### **Attestation Result**
+The outcome of the verification process, usually expressing whether the evidence is trustworthy.  
+
+---
+
+## 🔹 Attestation Roles (from IETF RATS)
+
+### **Attester**
+The device or system that generates evidence about its state.  
+
+### **Verifier**
+The system (in Veraison) that checks evidence and produces results.  
+
+### **Relying Party**
+The consumer of the attestation result (e.g., a cloud service that decides access based on trust).  
+
+---
+
+## 🔹 Claims & Tokens
+
+### **EAT (Entity Attestation Token)**
+A token format (CBOR/COSE or JSON/JWT) for representing attestation evidence and results.  
+
+### **Claims**
+Individual pieces of information inside evidence or results (e.g., firmware version, boot measurements).  
+
+---
+
+## 🔹 Other Relevant Terms
+
+### **Reference Values**
+Known-good measurements or metadata used to evaluate evidence.  
+
+### **Trust Anchor**
+A root cryptographic key or certificate used as the foundation of trust.  
+
+### **Endorser**
+The entity (often a manufacturer) that provides endorsements and reference values.  
+
+### **Verifier Plugin**
+A pluggable module in Veraison that implements verification for a particular scheme.  
+
+---

--- a/terminology.md
+++ b/terminology.md
@@ -8,8 +8,8 @@ It is intended to help new contributors, developers, and users quickly understan
 ## 🔹 Provisioning
 
 ### **CoRIM (Concise Reference Integrity Manifest)**
-A data structure that provides trusted reference values (baselines) for attestation.  
-It defines what "good" looks like for a platform or component.  
+A data format that provides trusted Reference Values (baselines) and Endorsements for remote attestation.  
+It defines what are "golden values" for a platform or component.  
 *(Defined in [IETF CoRIM draft](https://datatracker.ietf.org/doc/draft-birkholz-rats-corim/))*  
 
 ### **CoMID (Concise Module Identifier)**
@@ -27,10 +27,10 @@ Statements issued by manufacturers or trusted authorities about a device/compone
 Claims collected from a device (the Attester) about its current state (firmware, boot configuration, runtime properties).  
 
 ### **Scheme**
-A verification policy or method supported by Veraison that defines how evidence should be interpreted and matched against reference values.  
+A verification policy or method supported by Veraison that defines how Evidence should be interpreted and matched against Reference Values.  
 
 ### **Verifier**
-The entity that validates evidence against endorsements and reference values to produce an attestation result.  
+The entity that validates Evidence against Endorsements and Reference Values to produce an Attestation Result.  
 
 ### **Attestation Result**
 The outcome of the verification process, usually expressing whether the evidence is trustworthy.  
@@ -40,13 +40,13 @@ The outcome of the verification process, usually expressing whether the evidence
 ## 🔹 Attestation Roles (from IETF RATS)
 
 ### **Attester**
-The device or system that generates evidence about its state.  
+The device or system that generates Evidence about its state.  
 
 ### **Verifier**
-The system (in Veraison) that checks evidence and produces results.  
+An entity (typically a collection of components in Veraison) that  appraise Evidence and produces Attestation Results.  
 
 ### **Relying Party**
-The consumer of the attestation result (e.g., a cloud service that decides access based on trust).  
+The consumer of the Attestation Result (e.g., a cloud service that decides access based on trust).  
 
 ---
 


### PR DESCRIPTION
This PR adds a new `TERMINOLOGY.md` document that defines the key terms used in Project Veraison.  
It covers:
- Provisioning: CoRIM, CoMID, Endorsements
- Verification: Evidence, Scheme, Verifier, Attestation Result
- Attestation Roles (from RATS)
- Claims & Tokens (EAT, Claims)
- Other terms: Reference Values, Trust Anchor, Verifier Plugin

Closes #5 
