### PR TITLE
Update repository guide

### DIFF
--- a/repo-guide.md
+++ b/repo-guide.md
@@ -19,12 +19,6 @@ Compilation of documentation for various Veraison projects into a reader-friendl
 [community](https://github.com/veraison/community)
 Veraison community files. Look here for introductory presentations to the project and CCC membership materials.
 
-[veraison](https://github.com/veraison/veraison)
-This repo is used for managing conversations about Veraison features.
-
-[.github](https://github.com/veraison/.github)
-Veraison org-level files.
-
 [veraison.github.io](https://github.com/veraison/veraison.github.io) 
 Veraison project web site.
 

--- a/repo-guide.md
+++ b/repo-guide.md
@@ -19,8 +19,14 @@ Compilation of documentation for various Veraison projects into a reader-friendl
 [community](https://github.com/veraison/community)
 Veraison community files. Look here for introductory presentations to the project and CCC membership materials.
 
+[veraison](https://github.com/veraison/veraison)
+This repo is used for managing conversations about Veraison features.
+
+[.github](https://github.com/veraison/.github)
+Veraison org-level files.
+
 [veraison.github.io](https://github.com/veraison/veraison.github.io) 
-Currently a placeholder for veraison-project.org.
+Veraison project web site.
 
 ## Client Libraries
 Veraison services expose REST APIs. This set of libraries provides convenient code abstractions for the API model, to be used in client verification and provisioning applications.
@@ -45,11 +51,23 @@ Rust implementation of the Arm Confidential Computing Architecture (CCA) Attesta
 
 [parsec](https://github.com/veraison/parsec): Library support for handling the Parsec Key Attestation formats used in the attested TLS PoC.
 
+[ccaguest](https://github.com/veraison/ccaguest)
+A feature-rich tool for exploring CCA attestation.
+
+[rust-regl](https://github.com/veraison/rust-regl)
+Evidence generation library in Rust.
+
 ## Demos and Integration Examples
 
 [enact-demo](https://github.com/veraison/enact-demo): EnactTrust TPM/Veraison interop demo and related docs
 
 [keybroker-demo](https://github.com/veraison/keybroker-demo): A simple key broker protocol demonstration
+
+[cca-coserv-demo](https://github.com/veraison/cca-coserv-demo): CoSERV & Arm CCA end-to-end demo
+
+[ietf-110-hackathon-demo](https://github.com/veraison/ietf-110-hackathon-demo): docker compose based Attester / Verifier environment based on veraison components
+
+[ietf-115-hackathon](https://github.com/veraison/ietf-115-hackathon): IETF 115 hackathon work
 
 
 ## CLI tools 
@@ -70,12 +88,27 @@ Test case generator for CoRIM-related testing and validation
 [cca-realm-measurements](https://github.com/veraison/cca-realm-measurements)
 A tool to calculate Realm Initial Measurements and Realm Extended Measurements for Arm CCA
 
+[cocli](https://github.com/veraison/cocli)
+CLI tool to manipulate CoRIM and CoMIDs
+
+[corim-tool](https://github.com/veraison/corim-tool)
+A CLI for working with CoRIMs based on corim-rs.
+
+[cover](https://github.com/veraison/cover)
+CoRIM Verifier
+
+[go-gen-ref](https://github.com/veraison/go-gen-ref)
+Tool to generate reference values for the SEV-SNP scheme
+
 ## Standards driven work
 The Veraison Project supports Attestation related working groups in standards bodies, in particular IETF & TCG. This set of repos provide test bed implementations for some of the standards work, as related to Veraison services.
 
 #### EAT
 [eat](https://github.com/veraison/eat) 
 Golang library for manipulating Entity Attestation Tokens (draft-ietf-rats-eat).
+
+[da](https://github.com/veraison/da)
+Golang implementation of draft-poirier-rats-eat-da.
 
 #### EAR
 These libraries provide functions for working with EAR (EAT Attestation Results), an EAT/JWT serialisation of the Attestation Result for Secure Interactions (AR4SI) information model - see draft-fv-rats-ear
@@ -91,14 +124,20 @@ These libraries provide functions for working with EAR (EAT Attestation Results)
 
 [ratsd](https://github.com/veraison/ratsd): A RATS conceptual message collection daemon
 
+[coserv-rs](https://github.com/veraison/coserv-rs): Rust implementation of CoSERV data types and API bindings
+
 ####  Verifier Provisioning 
 These libraries provide support for the standard information models used to convey data to a Verifier.
 
-[corim](https://github.com/veraison/corim): manipulation of Concise Reference Integrity Manifest (CoRIM) and Concise Module Identifier (CoMID) tags. Also includes cocli CLI tool, that assists users creating CoRIM & CoMID tags.
+[corim](https://github.com/veraison/corim): manipulation of Concise Reference Integrity Manifest (CoRIM) and Concise Module Identifier (CoMID) tags.
 
 [corim-rs](https://github.com/veraison/corim-rs): Rust implementation of CoRIM and CoMID manipulation library
 
+[corim-store](https://github.com/veraison/corim-store): An endorsement store based on CoRIM, implemented on top of a relational DBMS.
+
 [swid](https://github.com/veraison/swid) : SWID and CoSWID manipulation library
+
+[endorsement-store-protobuf-test](https://github.com/veraison/endorsement-store-protobuf-test): Prototyping endorsement store interface using protobufs.
 
 #### COSE
 [go-cose](https://github.com/veraison/go-cose): go library for CBOR Object Signing and Encryption (COSE)
@@ -110,7 +149,7 @@ flowchart TD
 VR("Veraison Roles")
 style VR fill:#f9f,stroke:#333,stroke-width:4px
 LG["<b>Logical Group</b> \n <i>Repository name</i>"]
-subgraph Daigram[<b>Daigram Convention</b>]
+subgraph Diagram[<b>Diagram Convention</b>]
 
 VR  -->| Direct Usage | LG
 VR  -.-> | Possible Usage | LG
@@ -121,7 +160,7 @@ end
 
 ```mermaid
 flowchart TD
-subgraph Veraison["<b>Core Structure </b?"]
+subgraph Veraison["<b>Core Structure </b>"]
 style Veraison stroke:#333,stroke-width:4px
 
 SP("Supply Chain")
@@ -133,19 +172,30 @@ style ATT fill:#f9f,stroke:#333,stroke-width:4px
 COCLI["<b>Endorsement Manipulation CLI Tool</b>
  <i>cocli</i>"]
 
-GEN-CORIM["<b>Endorsement creation from Evidence CLI Tool</b>
+GENCORIM["<b>Endorsement creation from Evidence CLI Tool</b>
  <i>gen-corim</i>"]
+
+GENREF["<b>Reference Value Generation Tool</b>
+ <i>go-gen-ref</i>"]
 
 VPF["<b>Verifier Provisioning Formats</b>
  <i>corim</i>
  <i>corim-rs</i>
- <i>coswid</i>"]
+ <i>swid</i>
+ <i>coserv-rs</i>"]
 COCLI ---> VPF
+GENCORIM ---> VPF
+GENREF ---> VPF
 
 CL["<b>Common Libraries</b> 
      <i>go-cose</i>"]
 
 VPF ---> CL
+
+ESTORE["<b>Endorsement Stores</b>
+ <i>corim-store</i>
+ <i>endorsement-store-protobuf-test</i>"]
+ESTORE ---> VPF
 
 EF["<b>Evidence Formats</b> 
      <i>dice</i>
@@ -153,8 +203,9 @@ EF["<b>Evidence Formats</b>
      <i>psatoken</i>
      <i>ccatoken</i>
      <i>rust-ccatoken</i>
-     <i>enacttrust-tpm</i>
-     <i>parsec (tpm, cca)</i>"]
+     <i>parsec (tpm)</i>
+     <i>rust-regl</i>
+     <i>da</i>"]
 EF ---> CL
 
 SD["<b>Core Verifier repositories</b> 
@@ -183,10 +234,13 @@ Verifier ---> AR
 
 
 Verifier ---> VPF
+Verifier ---> ESTORE
 Verifier ---> CL
 Verifier ---> EF
 
 SP ---> COCLI
+SP ---> GENCORIM
+SP ---> GENREF
 
 API["<b>API CLIENT LIBRARIES</b>
     <i>apiclient</i>
@@ -197,12 +251,24 @@ SP  -.-> API
 EVCLI["<b>Evidence Manipulation CLI Tool</b> \n <i>evcli</i> "]
 EVCLI ---> API
 
+CCATOOLS["<b>CCA Tools</b>
+      <i>ccaguest</i>
+      <i>cca-realm-measurements</i>"]
+CCATOOLS ---> EF
+
+CORIMTOOLS["<b>CoRIM CLI Tools</b>
+      <i>corim-tool</i>
+      <i>cover</i>"]
+CORIMTOOLS ---> VPF
+
 CMW["<b>CONCEPTUAL MESSAGE WRAPPER</b>
       <i>cmw</i>
-      <i>rust-cmw</i>"]
+      <i>rust-cmw</i>
+      <i>coserv-rs</i>"]
 
 ATT --->EF
 ATT -.-> EVCLI
+ATT -.-> CCATOOLS
 EVCLI ---> EF
 API ---> CMW
 Verifier ---> CMW
@@ -222,10 +288,26 @@ end
 ```mermaid
 flowchart TD
 VA["
+    <i>.github</i>
     <i>community</i> 
+    <i>veraison</i>
     <i>veraison.github.io</i>"]
 subgraph Veraison["<b>Administrative Repositories</b>"]
 VA
+end
+
+```
+
+```mermaid
+flowchart TD
+VD["
+    <i>cca-coserv-demo</i>
+    <i>enact-demo</i>
+    <i>ietf-110-hackathon-demo</i>
+    <i>ietf-115-hackathon</i>
+    <i>keybroker-demo</i>"]
+subgraph Veraison["<b>Demos and Integration Examples</b>"]
+VD
 end
 
 ```

--- a/repo-guide.md
+++ b/repo-guide.md
@@ -65,11 +65,6 @@ Evidence generation library in Rust.
 
 [cca-coserv-demo](https://github.com/veraison/cca-coserv-demo): CoSERV & Arm CCA end-to-end demo
 
-[ietf-110-hackathon-demo](https://github.com/veraison/ietf-110-hackathon-demo): docker compose based Attester / Verifier environment based on veraison components
-
-[ietf-115-hackathon](https://github.com/veraison/ietf-115-hackathon): IETF 115 hackathon work
-
-
 ## CLI tools 
 CLI tools for illustrative interactions with attestation tokens or a Veraison service. Used for demos & integration testing.
 
@@ -137,8 +132,6 @@ These libraries provide support for the standard information models used to conv
 
 [swid](https://github.com/veraison/swid) : SWID and CoSWID manipulation library
 
-[endorsement-store-protobuf-test](https://github.com/veraison/endorsement-store-protobuf-test): Prototyping endorsement store interface using protobufs.
-
 #### COSE
 [go-cose](https://github.com/veraison/go-cose): go library for CBOR Object Signing and Encryption (COSE)
 
@@ -194,7 +187,7 @@ VPF ---> CL
 
 ESTORE["<b>Endorsement Stores</b>
  <i>corim-store</i>
- <i>endorsement-store-protobuf-test</i>"]
+ "]
 ESTORE ---> VPF
 
 EF["<b>Evidence Formats</b> 
@@ -303,8 +296,6 @@ flowchart TD
 VD["
     <i>cca-coserv-demo</i>
     <i>enact-demo</i>
-    <i>ietf-110-hackathon-demo</i>
-    <i>ietf-115-hackathon</i>
     <i>keybroker-demo</i>"]
 subgraph Veraison["<b>Demos and Integration Examples</b>"]
 VD


### PR DESCRIPTION
## Summary
- add currently active Veraison repos that were missing from the guide
- refresh stale project and provisioning entries
- update the repository organisation Mermaid diagrams

## Testing
- git diff --check

Note: no Mermaid CLI or repo-level docs validation target was available in this checkout.