### PR TITLE
Clarify challenge-response nonce encoding

### DIFF
--- a/api/challenge-response/README.md
+++ b/api/challenge-response/README.md
@@ -69,8 +69,9 @@ session expiry has elapsed.
 ```
 
 `nonceSize` must be between `8` and `64`. Analogously, `nonce` must be
-URL-safe base64 encoded and between 8 and 64 bytes when decoded (which means
-the specified base64 string must be no longer than 88 bytes).
+base64url encoded without padding and between 8 and 64 bytes when decoded
+(which means the specified encoded string must be no longer than 86
+characters).
 
 ### Asynchronous verification
 

--- a/api/challenge-response/README.md
+++ b/api/challenge-response/README.md
@@ -59,7 +59,7 @@ session expiry has elapsed.
   Location: https://veraison.example/challenge-response/v1/session/1234567890
 
   {
-    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI",
     "expiry": "2030-10-12T07:20:50.52Z",
     "accept": [
       "application/psa-attestation-token"
@@ -68,9 +68,9 @@ session expiry has elapsed.
   }
 ```
 
-`nonceSize` must be between `8` and `64`. Analogously, `nonce` must be between
-8 and 64 bytes when decoded (which means the specified base64 string must be no
-longer than 88 bytes).
+`nonceSize` must be between `8` and `64`. Analogously, `nonce` must be
+URL-safe base64 encoded and between 8 and 64 bytes when decoded (which means
+the specified base64 string must be no longer than 88 bytes).
 
 ### Asynchronous verification
 
@@ -90,7 +90,7 @@ longer than 88 bytes).
   Content-format: application/vnd.veraison.challenge-response-session+json
 
   {
-    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI",
     "expiry": "2031-10-12T07:20:50.52Z",
     "accept": [
       "application/psa-attestation-token"
@@ -116,7 +116,7 @@ longer than 88 bytes).
   Content-format: application/vnd.veraison.challenge-response-session+json
 
   {
-    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI",
     "expiry": "2031-10-12T07:20:50.52Z",
     "accept": [
       "application/psa-attestation-token"
@@ -154,7 +154,7 @@ longer than 88 bytes).
   Content-format: application/vnd.veraison.challenge-response-session+json
 
   {
-    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+    "nonce": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI",
     "expiry": "2030-10-12T07:20:50.52Z",
     "accept": [
       "application/psa-attestation-token"

--- a/api/challenge-response/challenge-response.yaml
+++ b/api/challenge-response/challenge-response.yaml
@@ -36,7 +36,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: '^[A-Za-z0-9_-]+={0,2}$'
+            format: base64url
       responses:
         '201':
           description: >

--- a/api/challenge-response/challenge-response.yaml
+++ b/api/challenge-response/challenge-response.yaml
@@ -30,13 +30,13 @@ paths:
           in: query
           description: >
             the API server should not generate a nonce for this session and
-            instead use the one supplied by the client. The supplied base64
-            URL-encoded value must decode to a byte sequence between 8 and
-            64 bytes long.
+            instead use the one supplied by the client. The supplied nonce
+            MUST be URL-safe base64 encoded and must decode to a byte sequence
+            between 8 and 64 bytes long.
           required: false
           schema:
             type: string
-            format: byte
+            pattern: '^[A-Za-z0-9_-]+={0,2}$'
       responses:
         '201':
           description: >

--- a/api/challenge-response/challenge-response.yaml
+++ b/api/challenge-response/challenge-response.yaml
@@ -31,8 +31,8 @@ paths:
           description: >
             the API server should not generate a nonce for this session and
             instead use the one supplied by the client. The supplied nonce
-            MUST be URL-safe base64 encoded and must decode to a byte sequence
-            between 8 and 64 bytes long.
+            MUST be base64url encoded without padding and must decode to a byte
+            sequence between 8 and 64 bytes long.
           required: false
           schema:
             type: string

--- a/api/challenge-response/schemas/components.yaml
+++ b/api/challenge-response/schemas/components.yaml
@@ -8,11 +8,12 @@ components:
       properties:
         nonce:
           type: string
-          format: byte
+          pattern: '^[A-Za-z0-9_-]+={0,2}$'
           description:
-            base64 encoded random value. Must be between 8 and 64 bytes long in
-            its raw form (the base64 encoding must be no longer than 88 bytes).
-          example: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+            URL-safe base64 encoded random value. Must be between 8 and 64
+            bytes long in its raw form (the base64 encoding must be no longer
+            than 88 bytes).
+          example: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI
         expiry:
           type: string
           format: date-time

--- a/api/challenge-response/schemas/components.yaml
+++ b/api/challenge-response/schemas/components.yaml
@@ -10,9 +10,9 @@ components:
           type: string
           format: base64url
           description:
-            URL-safe base64 encoded random value. Must be between 8 and 64
-            bytes long in its raw form (the base64 encoding must be no longer
-            than 88 bytes).
+            Base64url-encoded random value without padding. Must be between 8
+            and 64 bytes long in its raw form (the encoded value must be no
+            longer than 86 characters).
           example: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI
         expiry:
           type: string

--- a/api/challenge-response/schemas/components.yaml
+++ b/api/challenge-response/schemas/components.yaml
@@ -8,7 +8,7 @@ components:
       properties:
         nonce:
           type: string
-          pattern: '^[A-Za-z0-9_-]+={0,2}$'
+          format: base64url
           description:
             URL-safe base64 encoded random value. Must be between 8 and 64
             bytes long in its raw form (the base64 encoding must be no longer


### PR DESCRIPTION
## Summary
- specify challenge-response nonces as URL-safe base64
- update examples and schemas to use a URL-safe base64 pattern

## Testing
- make check (api/challenge-response)